### PR TITLE
Setting attributes in the instance

### DIFF
--- a/src/instance.js
+++ b/src/instance.js
@@ -14,8 +14,9 @@ function fakeModelInstance (defaults, obj) {
 	this._values.createdAt = this._values.createdAt || new Date();
 	this._values.updatedAt = this._values.updatedAt || new Date();
 
-	_.forEach(this._values, function(value, key) {
-		this[key] = value
+	var instance = this;
+	_.forEach(instance._values, function(value, key) {
+		instance[key] = value
 	});
 }
 fakeModelInstance.prototype.set = function(key, val) { this._values[key] = val; };

--- a/src/instance.js
+++ b/src/instance.js
@@ -13,6 +13,10 @@ function fakeModelInstance (defaults, obj) {
 	this._values.id = this._values.id || id;
 	this._values.createdAt = this._values.createdAt || new Date();
 	this._values.updatedAt = this._values.updatedAt || new Date();
+
+	_.forEach(this._values, function(value, key) {
+		this[key] = value
+	});
 }
 fakeModelInstance.prototype.set = function(key, val) { this._values[key] = val; };
 fakeModelInstance.prototype.get = function (key) { return this._values[key]; };

--- a/src/model.js
+++ b/src/model.js
@@ -14,9 +14,15 @@ function fakeModel (name, defaults, opts) {
 	this.name = name;
 	this._defaults = defaults || {};
 	this._functions = {};
+	this._classFunctions = {};
 	if(opts && opts.instanceMethods) {
 		_.extend(this._functions, opts.instanceMethods);
 	}
+
+	if(opts && opts.classMethods) {
+		_.extend(this._classFunctions, opts.classMethods);
+	}
+
 	this._wasCreated = true;
 	this.Instance = {};
 	this.Instance.prototype = this._functions;


### PR DESCRIPTION
This allows users to use Model.attribute instead of Model.get('attribute').